### PR TITLE
fix(images): replace image package

### DIFF
--- a/bccm_core/lib/src/utils/images.dart
+++ b/bccm_core/lib/src/utils/images.dart
@@ -1,7 +1,7 @@
 import 'package:bccm_core/bccm_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_image/network.dart';
+import 'package:extended_image/extended_image.dart';
 
 const Map<ImageCropMode, String> _imageCropModeQueryParam = {
   ImageCropMode.faces: 'faces',
@@ -74,9 +74,11 @@ ImageProvider<Object> networkImageWithRetryAndResize({
   return ResizeImage.resizeIfNeeded(
     null,
     cacheHeight,
-    NetworkImageWithRetry(
+    ExtendedNetworkImageProvider(
       imageUrl,
       headers: const {'Keep-Alive': 'timeout=20, max=5'},
+      retries: 3,
+      timeRetry: const Duration(milliseconds: 100),
     ),
   );
 }

--- a/bccm_core/pubspec.yaml
+++ b/bccm_core/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   flutter_appauth: ^7.0.1
   flutter_hooks: ^0.20.5
-  flutter_image: ^4.1.10
+  extended_image: ^9.1.0
   flutter_local_notifications: ^17.2.3
   flutter_riverpod: ^2.5.3
   flutter_secure_storage: ^9.2.2


### PR DESCRIPTION
Quite a bit of errors in Sentry seems to be from images.

Eg. the `networkImageWithRetryAndResize` util in bccm_core. 
It has used `NetworkImageWithRetry`, but that specific widget seems to crash out quite often.

Other people seems to have found success by simply switching to the `extended_image` package, so I'll try that.